### PR TITLE
Move initialization to constructor to solve multiple doors sharing same state and listener

### DIFF
--- a/custom_components/powerpetdoor/button.py
+++ b/custom_components/powerpetdoor/button.py
@@ -28,14 +28,15 @@ _LOGGER = logging.getLogger(__name__)
 
 class PetDoorButton(ButtonEntity):
     _attr_should_poll = False
-    last_state = None
-    power = True
 
     def __init__(self,
                  client: PowerPetDoorClient,
                  name: str,
                  device: DeviceInfo | None = None) -> None:
         self.client = client
+
+        self.last_state = None
+        self.power = True
 
         self._attr_name = name
         self._attr_device_info = device

--- a/custom_components/powerpetdoor/cover.py
+++ b/custom_components/powerpetdoor/cover.py
@@ -43,9 +43,6 @@ class PetDoor(CoordinatorEntity, CoverEntity):
     _attr_supported_features = (SUPPORT_CLOSE | SUPPORT_OPEN)
     _attr_position = None
 
-    last_change = None
-    power = True
-
     def __init__(self,
                  hass: HomeAssistant,
                  client: PowerPetDoorClient,
@@ -61,6 +58,9 @@ class PetDoor(CoordinatorEntity, CoverEntity):
 
         super().__init__(coordinator)
         self.client = client
+
+        self.last_change = None
+        self.power = True
 
         self._attr_name = name
         self._attr_device_info = device

--- a/custom_components/powerpetdoor/number.py
+++ b/custom_components/powerpetdoor/number.py
@@ -85,9 +85,6 @@ NUMBERS = {
 }
 
 class PetDoorNumber(CoordinatorEntity, NumberEntity):
-    last_change = None
-    power = True
-
     def __init__(self,
                  client: PowerPetDoorClient,
                  name: str,
@@ -97,6 +94,9 @@ class PetDoorNumber(CoordinatorEntity, NumberEntity):
         super().__init__(coordinator)
         self.client = client
         self.number = number
+
+        self.last_change = None
+        self.power = True
 
         self.multiplier = number.get("multiplier", 1.0)
 

--- a/custom_components/powerpetdoor/schedule.py
+++ b/custom_components/powerpetdoor/schedule.py
@@ -213,9 +213,6 @@ def compress_schedule(schedule: dict) -> dict:
 
 
 class PetDoorSchedule(CoordinatorEntity, Schedule):
-    last_change = None
-    power = True
-
     def __init__(self,
                  client: PowerPetDoorClient,
                  name: str,
@@ -231,6 +228,9 @@ class PetDoorSchedule(CoordinatorEntity, Schedule):
         Schedule.__init__(self, config=conf, editable=True)
         self.client = client
         self.schedule = schedule
+
+        self.last_change = None
+        self.power = True
 
         if "category" in schedule:
             self._attr_entity_category = schedule["category"]

--- a/custom_components/powerpetdoor/sensor.py
+++ b/custom_components/powerpetdoor/sensor.py
@@ -169,7 +169,6 @@ class PetDoorBattery(CoordinatorEntity, SensorEntity):
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = PERCENTAGE
 
-    last_change = None
     def __init__(self,
                  hass: HomeAssistant,
                  client: PowerPetDoorClient,
@@ -185,6 +184,8 @@ class PetDoorBattery(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
 
         self.client = client
+
+        self.last_change = None
 
         self._attr_name = name
         self._attr_device_info = device
@@ -299,9 +300,6 @@ class PetDoorBattery(CoordinatorEntity, SensorEntity):
         return self.coordinator.data.get(FIELD_AC_PRESENT) if self.coordinator.data else None
 
 class PetDoorStats(CoordinatorEntity, SensorEntity):
-    last_change = None
-    power = True
-
     def __init__(self,
                  client: PowerPetDoorClient,
                  name: str,
@@ -311,6 +309,9 @@ class PetDoorStats(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.client = client
         self.sensor = sensor
+
+        self.last_change = None
+        self.power = True
 
         self._attr_name = name
         self._attr_entity_category = sensor.get("category")

--- a/custom_components/powerpetdoor/switch.py
+++ b/custom_components/powerpetdoor/switch.py
@@ -164,8 +164,6 @@ NOTIFICATION_SWITCHES = {
 
 class PetDoorSwitch(CoordinatorEntity, ToggleEntity):
     _attr_device_class = SwitchDeviceClass.SWITCH
-    last_change = None
-    power = True
 
     def __init__(self,
                  client: PowerPetDoorClient,
@@ -176,6 +174,9 @@ class PetDoorSwitch(CoordinatorEntity, ToggleEntity):
         super().__init__(coordinator)
         self.client = client
         self.switch = switch
+
+        self.last_change = None
+        self.power = True
 
         self._attr_name = name
         self._attr_entity_category = switch.get("category")
@@ -250,8 +251,6 @@ class PetDoorSwitch(CoordinatorEntity, ToggleEntity):
 class PetDoorNotificationSwitch(CoordinatorEntity, ToggleEntity):
     _attr_device_class = SwitchDeviceClass.SWITCH
     _attr_entity_category = EntityCategory.CONFIG
-    last_change = None
-    power = True
 
     def __init__(self,
                  client: PowerPetDoorClient,
@@ -262,6 +261,9 @@ class PetDoorNotificationSwitch(CoordinatorEntity, ToggleEntity):
         super().__init__(coordinator)
         self.client = client
         self.switch = switch
+
+        self.last_change = None
+        self.power = True
 
         self._attr_name = name
         if "disabled" in switch:


### PR DESCRIPTION
### Issue
When multiple doors are added, the state shown in HomeAssistant is incorrect. One door's state is shown for all doors. Example:
1. If one door has Inside/Outside sensor OFF and other has ON, both doors in HA will show either OFF or ON.
2. Another issue reported here: https://github.com/corporategoth/ha-powerpetdoor/issues/9

### Root Cause
In python, class level variables declared outside constructor are static and shared across instances. Example, consider following code:
```
class SomeClass:
    some_dict: dict[str, str] = {}

    def __init__() -> None:
        pass

    def add_value(self, key: str, value: str) -> None:
        self.some_dict[key] = value

var1 = SomeClass()
var1.add_value("k1", "v1")

var2 = SomeClass()
var2.add_value("k2", "v2")

// Both var1.some_dict and var2.some_dict will be {'k1': 'v1', 'k2': 'v2'}
```

### Fix
Fix is to move initialization into constructor. Taking above example, the fixed code will be: 
```
class SomeClass:
    def __init__() -> None:
        self.some_dict: dict[str, str] = {}

    def add_value(self, key: str, value: str) -> None:
        self.some_dict[key] = value

var1 = SomeClass()
var1.add_value("k1", "v1")

var2 = SomeClass()
var2.add_value("k2", "v2")

// var1.some_dict is {'k1': 'v1'} and  var2.some_dict is {'k2': 'v2'}
```
